### PR TITLE
feat: payable join

### DIFF
--- a/Backend/contracts/project.sol
+++ b/Backend/contracts/project.sol
@@ -10,19 +10,20 @@ import "@openzeppelin/contracts/utils/Strings.sol";
 
 contract EventPlatform {
 
-    int currentEventID = 0;
-    mapping(int => Event) public currentEvent;
+    uint256 currentEventID = 0;
+    mapping(uint256 => Event) public currentEvent;
     mapping(address => User) private registeredUser;
+    mapping(address => uint) pendingWithdrawals;
 
     struct Event {
-        int eventID;
+        uint256 eventID;
         string eventName;
         string description;
-        string date;
+        uint256 date; // unix timestamp
         string venue;
         uint maxParticipants;
         uint ageLimit;
-        uint64 fee;
+        uint256 fee; // in wei
         User admin;
         address[] participants;
         bool isVisible;
@@ -33,6 +34,9 @@ contract EventPlatform {
         string userName;
         uint age;
     }
+
+    event EventCreated(uint256 eventId, address creator, Event detail);
+    event EventJoined(uint256 eventId, address newParticipant);
 
     constructor(){
     }
@@ -53,14 +57,14 @@ contract EventPlatform {
         return registeredUser[userAddress];
     }
 
-    function isUserJoined(int eventID) public view returns (bool) {
+    function isUserJoined(uint256 eventID) public view returns (bool) {
         for (uint i = 0; i < currentEvent[eventID].participants.length; i++){
             if (currentEvent[eventID].participants[i] == msg.sender) return true;
         }
         return false;
     } 
 
-    function isUserJoined(address participant, int eventID) public view returns (bool) {
+    function isUserJoined(address participant, uint256 eventID) public view returns (bool) {
         for (uint i = 0; i < currentEvent[eventID].participants.length; i++){
             if (currentEvent[eventID].participants[i] == participant) return true;
         }
@@ -72,7 +76,7 @@ contract EventPlatform {
     }
 
     // Event-related functions
-    function addEvent(string memory eventName, string memory description, string memory date, string memory venue, uint maxParticipants, uint ageLimit, uint64 fee, bool isVisible) public {
+    function addEvent(string memory eventName, string memory description, uint256 date, string memory venue, uint maxParticipants, uint ageLimit, uint256 fee, bool isVisible) public {
         require(registeredUser[msg.sender].userAddress != address(0), "User is not yet registered");
         Event storage tmp = currentEvent[currentEventID];
         tmp.eventID = currentEventID;
@@ -85,10 +89,13 @@ contract EventPlatform {
         tmp.fee = fee;
         tmp.admin = registeredUser[msg.sender];
         tmp.isVisible = isVisible;
+        
+        emit EventCreated(currentEventID, msg.sender, tmp);
+
         currentEventID++;
     }
 
-    function editEvent(int eventID, string memory eventName, string memory description, string memory date, string memory venue, uint maxParticipants, uint ageLimit, uint64 fee, bool isVisible) public {
+    function editEvent(uint256 eventID, string memory eventName, string memory description, uint256 date, string memory venue, uint maxParticipants, uint ageLimit, uint64 fee, bool isVisible) public {
         require(eventID >= 0 && eventID < currentEventID, "Event does not exist");
         require(currentEvent[eventID].admin.userAddress == msg.sender, "Only admin can edit the event");
         currentEvent[eventID].eventName = eventName;
@@ -101,25 +108,38 @@ contract EventPlatform {
         currentEvent[eventID].isVisible = isVisible;
     }
 
-    // function joinEvent(int eventID) public payable {
-    function joinEvent(int eventID) public {
+    function joinEvent(uint256 eventID) public payable {
         require(eventID >= 0 && eventID < currentEventID, "Event does not exist");
         Event storage eventToJoin = currentEvent[eventID];
         User memory participant = registeredUser[msg.sender];
+
         require(participant.userAddress != address(0), "User is not registered. Please register first.");
         require(!isUserJoined(msg.sender, eventID), "User has already joined");
         require(getRemainingSeats(eventID) > 0,"Event is full");
         require(participant.age >= eventToJoin.ageLimit, string.concat("This event is not available to anyone under ", Strings.toString(eventToJoin.ageLimit)));
-        // require(msg.value >= eventToJoin.fee, "Not enough money in your account.");
-        // payable(eventToJoin.admin.userAddress).transfer(eventToJoin.fee);
+        require(msg.sender.balance >= eventToJoin.fee, "Not enough money in your account.");
+        require(msg.value >= eventToJoin.fee, "Not enough fee");
+
+        // fee is paid to admin and the excess amount is returned to sender
+        pendingWithdrawals[eventToJoin.admin.userAddress] += eventToJoin.fee;
+        pendingWithdrawals[msg.sender] += (msg.value - eventToJoin.fee);
         currentEvent[eventID].participants.push(msg.sender);
+
+        emit EventJoined(eventID, msg.sender);
     }
 
-    function getNumberOfEvents() public view returns (int) {
+    function getNumberOfEvents() public view returns (uint256) {
         return currentEventID;
     }
 
-    function getRemainingSeats(int eventID) public view returns (uint) {
+    function getRemainingSeats(uint256 eventID) public view returns (uint) {
         return currentEvent[eventID].maxParticipants - currentEvent[eventID].participants.length;
+    }
+
+    // use the "Withdrawal from Contracts" pattern from https://docs.soliditylang.org/en/v0.8.28/common-patterns.html#withdrawal-from-contracts 
+    function withdraw() public {
+        uint amount = pendingWithdrawals[msg.sender];
+        pendingWithdrawals[msg.sender] = 0;
+        payable(msg.sender).transfer(amount);
     }
 }


### PR DESCRIPTION
# Changelog
- changed `currentEventID ` form `int` to `uint256`
- added `payable` to `joinEvent`'s signature
- added events `EventCreated` and `EventJoined`
- use the `Withdrawals from Contract` pattern from solidity doc
  - in payable `joinEvent`, fee is paid to admin and the excess amount is returned to the sender
  - in `withDraw`, the user gets the ether
- the event fee is paid by `msg.value`
 
![螢幕截圖 2024-11-29 下午4 35 46](https://github.com/user-attachments/assets/e36dfcd8-429f-4417-ba50-dbc327e3131b)


```
// fee is paid to admin and the excess amount is returned to sender
pendingWithdrawals[eventToJoin.admin.userAddress] += eventToJoin.fee;
pendingWithdrawals[msg.sender] += (msg.value - eventToJoin.fee);
```

```
function withdraw() public {
        uint amount = pendingWithdrawals[msg.sender];
        pendingWithdrawals[msg.sender] = 0;
        payable(msg.sender).transfer(amount);
}
```
    